### PR TITLE
fix: :bug: relation direction when same node types

### DIFF
--- a/brahmand/src/query_engine/optimizer/traversal_sequence.rs
+++ b/brahmand/src/query_engine/optimizer/traversal_sequence.rs
@@ -37,7 +37,7 @@ pub fn get_relationship_table_name(
             return Ok(format!("{}_outgoing", rel_label));
         }
     }
-    
+
     if rel_table_schema.from_node == start_node_label {
         return Ok(format!("{}_outgoing", rel_label));
     }


### PR DESCRIPTION
When a graph like (a:User)-[:Follow]->(b:User) then the direction was incorrect and random