### PR TITLE
fix: :bug: Property tagging to node name

### DIFF
--- a/brahmand/src/query_engine/planner/logical_plan.rs
+++ b/brahmand/src/query_engine/planner/logical_plan.rs
@@ -133,7 +133,10 @@ mod tests {
             OperatorApplication {
                 operator: Operator::Equal,
                 operands: vec![
-                    Expression::Variable("age"),
+                    Expression::PropertyAccessExp(PropertyAccess {
+                        base: "n",
+                        key: "age"
+                    }),
                     Expression::Literal(Literal::Integer(30)),
                 ],
             }


### PR DESCRIPTION
if name node exist then we tag the condition to that node. 
This way if the node is selected at last then it will have property access instead of variable.                         
The variable and literal will work in case early filtering within CTES. 
But for final where conditions, we will need the node name to get the proper column from that node          

```cypher             
e.g ->  MATCH (a:User {username: 'Sam'})-[:FOLLOWS]->(x:User)<-[:FOLLOWS]-(b:User) 
WHERE b.username <> 'Sam'                                 
RETURN a.username AS userA, b.username AS userB, count(x) AS common;                         
```
SQL final select part -    
```sql                     
SELECT a.username AS userA, b.username AS userB, count(x.userId) AS common                         
FROM User AS a                         
JOIN ... WHERE username = 'Sam' GROUP BY userA, userB
```                         
This final `username = 'Sam'` is ambiguous. If we use propAccess then it will be 
```sql 
JOIN ... WHERE a.username = 'Sam' GROUP BY userA, userB
```